### PR TITLE
エラーが起こったらデバッガを起動しようとせず終了する。

### DIFF
--- a/sampleAI.lisp
+++ b/sampleAI.lisp
@@ -1,3 +1,12 @@
+;; sb-exit:quit を使っている警告を消す。
+(declaim (sb-ext:muffle-conditions cl:warning))
+
+;; エラーが起こったら終了する。
+(setf sb-ext:*invoke-debugger-hook*
+      (lambda (condition hook)
+        (declare (ignore condition hook))
+        (sb-ext:quit :recklessly-p t)))
+
 (ql:quickload :jonathan :silent t)
 
 (defun map-mode (data)

--- a/sampleAI.lisp
+++ b/sampleAI.lisp
@@ -1,4 +1,4 @@
-;; sb-exit:quit を使っている警告を消す。
+;; sb-ext:quit を使っている警告を消す。
 (declaim (sb-ext:muffle-conditions cl:warning))
 
 ;; エラーが起こったら終了する。


### PR DESCRIPTION
AIサーバーをデバッガから `(exit)` するなどして終了させると、サンプルAIが再現なくエラーを吐きつづけるので、終了するようにしました。