### PR TITLE
サンプルAIのスタートアップメッセージを抑制する。

### DIFF
--- a/ai.txt
+++ b/ai.txt
@@ -1,1 +1,1 @@
-sbcl --load sampleAI.lisp
+sbcl --noinform --load sampleAI.lisp


### PR DESCRIPTION
sbcl のスタートアップメッセージ `This is SBCL 1.3.3 ...` が AI の名前と間違われるので、スタートアップメッセージを省略する `--noinform` オプションを付けるようにしました。

![image](https://user-images.githubusercontent.com/1680210/31684956-62083354-b3bc-11e7-9412-3c3f7ce74ad5.png)
