### PR TITLE
--no-clear オプションが機能するようにした。

### DIFF
--- a/mogeRPGserver.lisp
+++ b/mogeRPGserver.lisp
@@ -102,7 +102,8 @@
   (sb-ext:run-program "/bin/sh" (list "-c" cmd) :input nil :output *standard-output*))
 
 (defun gamen-clear ()
-  (sh "clear"))
+  (when *gamen-clear?*
+    (sh "clear")))
 
 ;;ゲームオーバーメッセージ
 (defun game-over-message (p)


### PR DESCRIPTION
画面のクリアを省略するオプションです。ディレイ0の時により高速に冒険が終わります。また、冒険が終わってからログが見返しやすいかと思います。