### PR TITLE
さまざまなエラーが起こった時にメッセージを表示して終了する処理を追加した。

### DIFF
--- a/mogeRPGserver.lisp
+++ b/mogeRPGserver.lisp
@@ -795,7 +795,8 @@
                                (format t "~A~%" c)
                                (sb-ext:exit))
    (end-of-file (c) ;;AIからデータを受け取ることができない。
-                (format t "~A~%" c))))
+                (format t "~A~%" c)
+                (sb-ext:exit))))
 
 (defun set-random-seed (n)
   (dotimes (i n)

--- a/mogeRPGserver.lisp
+++ b/mogeRPGserver.lisp
@@ -102,6 +102,8 @@
 	(concatenate 'string string (make-string pad :initial-element #\ ))
         string)))
 
+(define-condition handshake-error (error) ())
+
 ;;ai.txtからai起動するコマンドを読み込む
 ;;*ai* ストリーム？
 (defun load-ai ()
@@ -114,7 +116,14 @@
                   :wait nil
                   :search t))
     (setf *ai* (make-two-way-stream (process-output *proc*) (process-input *proc*)))
-    (setf *ai-name* (read-line *ai*))
+    (handler-case
+     (setf *ai-name* (read-line *ai*))
+     (end-of-file (c)
+                  (format t "~A~%" c)
+                  (error 'handshake-error)))
+    (when (equal *ai-name* "")
+      (format t "AIの名前が空です。~%")
+      (error 'handshake-error))
     (setf atama (char *ai-name* 0))
     (cond
       ((= 2 (moge-char-width atama))
@@ -766,17 +775,36 @@
 ;;ゲーム開始
 (defun main ()
   (parse-args)
-  (load-ai)
+  (handler-case
+   (load-ai)
+   (simple-error (c) ;;AIコマンドが存在しない、実行許可がないなど
+                 (format t "~A~%" c)
+                 (sb-ext:exit))
+   (handshake-error (c)
+                (format t "AIから名前を受け取ることができませんでした。~%")
+                (sb-ext:exit)))
   #+nil (setf *random-state* (make-random-state t))
-  (let* ((p (make-player)) 
-	 (map (make-donjon)))
-    (init-data) ;;データ初期化
-    (maze map p) ;;マップ生成
-    (main-game-loop map p)))
+  (handler-case
+   (let* ((p (make-player)) 
+          (map (make-donjon)))
+     (init-data) ;;データ初期化
+     (maze map p) ;;マップ生成
+     (main-game-loop map p))
+   (sb-int:simple-stream-error (c) ;;AIの終了などによってデータの受け渡しができない。
+                               (format t "ストリームエラーが発生しました。~%")
+                               (format t "~A~%" c)
+                               (sb-ext:exit))
+   (end-of-file (c) ;;AIからデータを受け取ることができない。
+                (format t "~A~%" c))))
 
 (defun set-random-seed (n)
   (dotimes (i n)
     (random 2)))
+
+(defun parse-non-negative-number (str)
+  (if (ppcre:scan "^(\\d+|\\d+\\.\\d+)$" str)
+      (read-from-string str)
+    (error)))
 
 (defun parse-args ()
   (opts:define-opts
@@ -793,17 +821,17 @@
      :description "マップモード時の表示のディレイ(小数可) デフォルト0"
      :short #\d
      :long "map-delay"
-     :arg-parser #'read-from-string)
+     :arg-parser #'parse-non-negative-number)
     (:name :battle-delay
      :description "バトル時の表示のディレイ(小数可) デフォルト0"
      :short #\b
      :long "battle-delay"
-     :arg-parser #'read-from-string)
+     :arg-parser #'parse-non-negative-number)
     (:name :moge-delay
      :description "もげぞう戦とハツネツ戦の表示のディレイ(小数可) デフォルト0"
      :short #\m
      :long "moge-delay"
-     :arg-parser #'read-from-string)
+     :arg-parser #'parse-non-negative-number)
     (:name :no-clear
      :description "画面のクリアをしない"
      :long "no-clear")
@@ -811,27 +839,42 @@
      :description "AIプログラムを起動するコマンドライン"
      :long "ai"
      :arg-parser #'identity))
-  (let ((options (opts:get-opts)))
-    (when (getf options :help)
-      (opts:describe
-       :prefix "もげRPGserver"
-       :usage-of "mogeRPGserver")
-      (sb-ext:exit))
-    (when (getf options :map-delay)
-      (setf *map-delay-seconds* (getf options :map-delay)))
-    (when (getf options :battle-delay)
-      (setf *battle-delay-seconds* (getf options :battle-delay)
-	    *bds* (getf options :battle-delay)))
-    (if (getf options :moge-delay)
-	(setf *boss-delay-seconds* (getf options :moge-delay))
-	(setf *boss-delay-seconds* *battle-delay-seconds*))
-    (if (getf options :random-seed)
-        (set-random-seed (getf options :random-seed))
-	(setf *random-state* (make-random-state t))) ; 環境から乱数を取得。
-    (when (getf options :no-clear)
-      (setf *gamen-clear?* nil))
-    (when (getf options :ai)
-      (setf *ai-command-line* (getf options :ai)))))
+  (handler-case
+   (multiple-value-bind
+       (options free-args)
+       (opts:get-opts)
+     (when free-args
+       (format t "解釈できないコマンドライン引数があります。~S~%" free-args)
+       (sb-ext:exit))
+     (when (getf options :help)
+       (opts:describe
+        :prefix "もげRPGserver"
+        :usage-of "mogeRPGserver")
+       (sb-ext:exit))
+     (when (getf options :map-delay)
+       (setf *map-delay-seconds* (getf options :map-delay)))
+     (when (getf options :battle-delay)
+       (setf *battle-delay-seconds* (getf options :battle-delay)
+             *bds* (getf options :battle-delay)))
+     (if (getf options :moge-delay)
+         (setf *boss-delay-seconds* (getf options :moge-delay))
+       (setf *boss-delay-seconds* *battle-delay-seconds*))
+     (if (getf options :random-seed)
+         (set-random-seed (getf options :random-seed))
+       (setf *random-state* (make-random-state t))) ; 環境から乱数を取得。
+     (when (getf options :no-clear)
+       (setf *gamen-clear?* nil))
+     (when (getf options :ai)
+       (setf *ai-command-line* (getf options :ai))))
+   (opts:unknown-option (c)
+    (format t "不明なオプションです。~A~%" (opts:option c))
+    (sb-ext:exit))
+   (opts:missing-arg (c)
+    (format t "オプション ~A に引数がありません。~%" (opts:option c))
+    (sb-ext:exit))
+   (opts:arg-parser-failed (c)
+    (format t "オプション ~A への引数 ~A が解釈できません。~%" (opts:option c) (opts:raw-arg c))
+    (sb-ext:exit))))
 
 ;;壁破壊
 (defun kabe-break (map p y x)


### PR DESCRIPTION
1. AIプログラムを起動できない場合
2. AIが名前として空行を送って来た場合
3. AIの予期せぬ終了などでパイプへの書き込み、読み込みができない場合
4. サーバーのコマンドライン指定がおかしい場合

```
$ ./mogeRPGserver --ai 'hoge'
Couldn't execute "hoge": そのようなファイルやディレクトリはありません

$ ./mogeRPGserver --ai 'echo'
AIの名前が空です。
AIから名前を受け取ることができませんでした。

$ ./mogeRPGserver --ai 'echo -n'
end of file on #<TWO-WAY-STREAM
                 :INPUT-STREAM #<SB-SYS:FD-STREAM for "descriptor 6" {1002DFAB93}>
                 :OUTPUT-STREAM #<SB-SYS:FD-STREAM for "descriptor 5" {1002DFA763}>>
AIから名前を受け取ることができませんでした。

$ ./mogeRPGserver --ai 'echo AI'
ストリームエラーが発生しました。
Couldn't write to #<SB-SYS:FD-STREAM for "descriptor 5" {1002DFAAA3}>:
  Broken pipe

$ ./mogeRPGserver -x
不明なオプションです。-x

$ ./mogeRPGserver hoge
解釈できないコマンドライン引数があります。("hoge")

$ ./mogeRPGserver -d
オプション -d に引数がありません。

$ ./mogeRPGserver -d hoge
オプション -d への引数 hoge が解釈できません。
```